### PR TITLE
Add single-file Valkenswaard community poll webpage

### DIFF
--- a/valkenswaard.html
+++ b/valkenswaard.html
@@ -1,0 +1,412 @@
+<!doctype html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pingwi – Valkenswaard Poll</title>
+  <meta name="description" content="Lokale community poll voor Valkenswaard: welke winkel, dienst of bedrijf mist Valkenswaard het meest?" />
+  <style>
+    :root {
+      --bg: #ffffff;
+      --surface: #ffffff;
+      --text: #13213b;
+      --muted: #60708f;
+      --primary: #2d7fff;
+      --primary-dark: #2167d6;
+      --border: #e6ebf5;
+      --shadow: 0 10px 28px rgba(18, 36, 74, 0.08);
+      --radius: 18px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.45;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+    }
+
+    .container {
+      width: min(100% - 2rem, 860px);
+      margin: 0 auto;
+    }
+
+    header {
+      padding: 1rem 0 0.5rem;
+    }
+
+    .brand {
+      font-size: 1.25rem;
+      font-weight: 800;
+      letter-spacing: 0.2px;
+    }
+
+    .subtitle {
+      margin-top: 0.2rem;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .hero {
+      padding: 1.75rem 0 1.25rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+    }
+
+    .lead {
+      margin: 0.85rem 0 0;
+      color: var(--muted);
+      font-size: 1.03rem;
+    }
+
+    .counter {
+      margin-top: 0.9rem;
+      display: inline-flex;
+      align-items: center;
+      padding: 0.45rem 0.75rem;
+      background: #f5f8ff;
+      border: 1px solid #e6efff;
+      border-radius: 999px;
+      color: #315ca0;
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    .input-card,
+    .results {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+    }
+
+    .input-card {
+      margin: 1rem 0 1.35rem;
+      padding: 0.95rem;
+    }
+
+    form {
+      display: grid;
+      gap: 0.65rem;
+      grid-template-columns: 1fr;
+    }
+
+    input[type="text"] {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 0.85rem 0.95rem;
+      font-size: 1rem;
+      outline: none;
+      transition: border-color 160ms ease, box-shadow 160ms ease;
+    }
+
+    input[type="text"]:focus {
+      border-color: #9ec0ff;
+      box-shadow: 0 0 0 3px rgba(45, 127, 255, 0.13);
+    }
+
+    button {
+      border: 0;
+      border-radius: 12px;
+      padding: 0.82rem 1rem;
+      font-size: 0.98rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 8px 18px rgba(45, 127, 255, 0.26);
+    }
+
+    .btn-primary:hover,
+    .btn-primary:focus-visible {
+      background: var(--primary-dark);
+      transform: translateY(-1px);
+    }
+
+    .btn-primary:active { transform: translateY(0); }
+
+    .error {
+      color: #b73752;
+      font-size: 0.9rem;
+      min-height: 1.2em;
+      margin: 0.25rem 0 0;
+    }
+
+    .results {
+      padding: 0.7rem;
+      margin-bottom: 1.3rem;
+    }
+
+    .result-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .item {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 0.8rem;
+      display: grid;
+      gap: 0.7rem;
+      align-items: center;
+      background: #fff;
+      transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+    }
+
+    .item:hover {
+      transform: translateY(-2px);
+      border-color: #d7e3f9;
+      box-shadow: 0 8px 20px rgba(17, 45, 99, 0.09);
+    }
+
+    .item-title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+      word-break: break-word;
+    }
+
+    .votes {
+      margin: 0;
+      color: var(--muted);
+      font-weight: 600;
+      font-size: 0.94rem;
+    }
+
+    .vote-btn {
+      justify-self: start;
+      background: #eff5ff;
+      color: #2c64bf;
+      border: 1px solid #dbe8ff;
+      padding: 0.52rem 0.85rem;
+      border-radius: 10px;
+      font-weight: 700;
+    }
+
+    .vote-btn:hover,
+    .vote-btn:focus-visible {
+      background: #e4efff;
+      transform: translateY(-1px);
+    }
+
+    footer {
+      padding: 0.5rem 0 1.8rem;
+      color: var(--muted);
+      text-align: center;
+      font-size: 0.9rem;
+    }
+
+    @media (min-width: 640px) {
+      .input-card { padding: 1.1rem; }
+
+      form {
+        grid-template-columns: 1fr auto;
+        align-items: center;
+      }
+
+      .item {
+        grid-template-columns: 1fr auto auto;
+        gap: 1rem;
+      }
+
+      .vote-btn { justify-self: end; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      * { transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <header class="container">
+    <div class="brand">Pingwi</div>
+    <div class="subtitle">Valkenswaard Community Poll</div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <h1>Welke zaak mist Valkenswaard?</h1>
+      <p class="lead">Deel jouw idee, stem mee en bekijk live resultaten.</p>
+      <div id="counter" class="counter" aria-live="polite">0 inwoners hebben meegedacht</div>
+    </section>
+
+    <section class="input-card" aria-label="Idee toevoegen">
+      <form id="idea-form" novalidate>
+        <input
+          id="idea-input"
+          type="text"
+          placeholder="Bijv. Aziatische supermarkt"
+          aria-label="Nieuw idee"
+          maxlength="80"
+        />
+        <button type="submit" class="btn-primary">Toevoegen</button>
+      </form>
+      <p id="error" class="error" aria-live="polite"></p>
+    </section>
+
+    <section class="results" aria-label="Resultaten">
+      <ul id="result-list" class="result-list"></ul>
+    </section>
+  </main>
+
+  <footer class="container">Een lokaal initiatief van Pingwi.com</footer>
+
+  <script>
+    // Lokale opslag sleutel
+    const STORAGE_KEY = 'pingwi_valkenswaard_poll_v1';
+
+    // Standaard ideeën als startdata
+    const defaultIdeas = [
+      { id: createId(), name: 'Aziatische supermarkt', votes: 0 },
+      { id: createId(), name: 'Gezellige coworkingplek', votes: 0 },
+      { id: createId(), name: 'Betaalbare sportschool', votes: 0 },
+      { id: createId(), name: 'Indoor speeltuin', votes: 0 },
+      { id: createId(), name: 'Bakker open op zondag', votes: 0 }
+    ];
+
+    const form = document.getElementById('idea-form');
+    const input = document.getElementById('idea-input');
+    const list = document.getElementById('result-list');
+    const errorBox = document.getElementById('error');
+    const counter = document.getElementById('counter');
+
+    let ideas = loadIdeas();
+    render();
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const name = input.value.trim();
+
+      if (!name) {
+        showError('Vul eerst een idee in.');
+        return;
+      }
+
+      const normalized = normalize(name);
+      const duplicate = ideas.some((idea) => normalize(idea.name) === normalized);
+
+      if (duplicate) {
+        showError('Dit idee staat er al tussen.');
+        return;
+      }
+
+      ideas.push({ id: createId(), name, votes: 0 });
+      saveIdeas();
+      clearError();
+      input.value = '';
+      render();
+      input.focus();
+    });
+
+    list.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-id]');
+      if (!button) return;
+
+      const id = button.getAttribute('data-id');
+      const idea = ideas.find((entry) => entry.id === id);
+      if (!idea) return;
+
+      idea.votes += 1;
+      saveIdeas();
+      render();
+    });
+
+    // Render: sorteren op stemmen (hoog naar laag) en daarna alfabetisch
+    function render() {
+      const sorted = [...ideas].sort((a, b) => {
+        if (b.votes !== a.votes) return b.votes - a.votes;
+        return a.name.localeCompare(b.name, 'nl');
+      });
+
+      list.innerHTML = sorted
+        .map((idea) => `
+          <li class="item">
+            <p class="item-title">${escapeHtml(idea.name)}</p>
+            <p class="votes">${idea.votes} ${idea.votes === 1 ? 'stem' : 'stemmen'}</p>
+            <button class="vote-btn" data-id="${idea.id}" type="button" aria-label="Stem op ${escapeHtml(idea.name)}">Stem</button>
+          </li>
+        `)
+        .join('');
+
+      const totalVotes = ideas.reduce((sum, item) => sum + item.votes, 0);
+      const totalContributions = ideas.length + totalVotes;
+      counter.textContent = `${totalContributions} inwoners hebben meegedacht`;
+    }
+
+    function loadIdeas() {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (!stored) {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultIdeas));
+          return [...defaultIdeas];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed) || parsed.length === 0) {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultIdeas));
+          return [...defaultIdeas];
+        }
+
+        // Minimale validatie van opgeslagen data
+        return parsed
+          .filter((item) => item && typeof item.name === 'string')
+          .map((item) => ({
+            id: typeof item.id === 'string' ? item.id : createId(),
+            name: item.name.trim(),
+            votes: Number.isFinite(item.votes) && item.votes >= 0 ? item.votes : 0
+          }))
+          .filter((item) => item.name.length > 0);
+      } catch {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(defaultIdeas));
+        return [...defaultIdeas];
+      }
+    }
+
+    function saveIdeas() {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(ideas));
+    }
+
+    function normalize(text) {
+      return text.toLocaleLowerCase('nl').replace(/\s+/g, ' ').trim();
+    }
+
+    function showError(message) {
+      errorBox.textContent = message;
+    }
+
+    function clearError() {
+      errorBox.textContent = '';
+    }
+
+    function createId() {
+      return `id-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    }
+
+    function escapeHtml(text) {
+      return text
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single-file, ready-to-deploy community voting page for Valkenswaard so residents can suggest missing businesses, vote and see live results without any backend or build step.

### Description
- Added `valkenswaard.html`, a self-contained page with inline HTML, CSS and vanilla JavaScript implementing header, hero, input form, live results list and footer.
- Preloaded example ideas and implemented client-side persistence using `localStorage`, case-insensitive duplicate prevention, empty-input validation, safe HTML escaping and a participation counter computed from submissions plus votes.
- Voting updates the UI immediately and the list is re-rendered sorted by votes (descending) with alphabetical tie-break; styles are mobile-first with rounded cards, soft shadows and smooth transitions.
- Accessibility and small UX touches included: ARIA live regions for dynamic text, input maxlength, focus handling and reduced-motion respect.

### Testing
- Ran a basic inline-asset check with a Python script that verified there are no external `script` or `link` assets and reported the file byte size, which passed (`basic inline-asset check passed, bytes= 10532`).
- Created and committed the new file to the repository via `git`, which succeeded and added `valkenswaard.html` to the index. 
- No automated unit tests exist for this static page; the automated checks above passed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e771a218d4832f89df555183a8448c)