### PR TITLE
Add Valkenswaard static poll page for Pingwi

### DIFF
--- a/valkenswaard.html
+++ b/valkenswaard.html
@@ -1,0 +1,528 @@
+<!doctype html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pingwi – Valkenswaard</title>
+  <meta name="description" content="Lokale community poll voor Valkenswaard." />
+  <style>
+    :root {
+      --bg: #ffffff;
+      --text: #17213b;
+      --muted: #6a7691;
+      --line: #e7ecf6;
+      --primary: #2e7cf6;
+      --primary-dark: #1f66d3;
+      --card-shadow: 0 10px 28px rgba(17, 35, 74, 0.08);
+      --radius: 18px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.45;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .container {
+      width: min(100% - 2rem, 860px);
+      margin-inline: auto;
+    }
+
+    header { padding: 1rem 0 0.35rem; }
+    .logo { font-weight: 800; font-size: 1.28rem; letter-spacing: 0.2px; }
+    .subtitle { color: var(--muted); font-size: 0.92rem; margin-top: 0.2rem; }
+
+    .hero { padding: 1.65rem 0 1.15rem; }
+    h1 {
+      margin: 0;
+      font-size: clamp(1.75rem, 4.5vw, 2.55rem);
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+    }
+    .lead { margin: 0.8rem 0 0; color: var(--muted); }
+
+    .counter {
+      margin-top: 0.9rem;
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 0.45rem 0.8rem;
+      background: #f4f8ff;
+      border: 1px solid #e7efff;
+      color: #325998;
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    .card {
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--card-shadow);
+    }
+
+    .form-card {
+      padding: 0.95rem;
+      margin-bottom: 1rem;
+    }
+
+    form {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.65rem;
+    }
+
+    input[type="text"] {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 0.86rem 0.95rem;
+      font-size: 1rem;
+      outline: none;
+      transition: border-color 160ms ease, box-shadow 160ms ease;
+    }
+    input[type="text"]:focus {
+      border-color: #98b9ff;
+      box-shadow: 0 0 0 3px rgba(46, 124, 246, 0.15);
+    }
+
+    button {
+      border: 0;
+      cursor: pointer;
+      border-radius: 12px;
+      font-weight: 700;
+      font-size: 0.98rem;
+      transition: transform 160ms ease, background-color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+    }
+
+    .btn-primary {
+      padding: 0.82rem 1rem;
+      color: #fff;
+      background: var(--primary);
+      box-shadow: 0 8px 18px rgba(46, 124, 246, 0.25);
+    }
+    .btn-primary:hover:enabled,
+    .btn-primary:focus-visible:enabled {
+      background: var(--primary-dark);
+      transform: translateY(-1px);
+    }
+
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+
+    .message {
+      min-height: 1.2rem;
+      margin: 0.6rem 0 0;
+      font-size: 0.93rem;
+      color: #2e5ca8;
+      font-weight: 600;
+    }
+
+    .suggestion {
+      margin-top: 0.5rem;
+      display: none;
+      align-items: center;
+      gap: 0.55rem;
+      flex-wrap: wrap;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+    .suggestion button {
+      background: #eff5ff;
+      border: 1px solid #d8e5ff;
+      color: #2a62bd;
+      padding: 0.45rem 0.72rem;
+      border-radius: 10px;
+    }
+    .suggestion button:hover:enabled { background: #e3eeff; }
+
+    .results {
+      padding: 0.7rem;
+      margin-bottom: 1.2rem;
+    }
+
+    .list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.65rem;
+    }
+
+    .idea {
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      padding: 0.8rem;
+      display: grid;
+      gap: 0.7rem;
+      background: #fff;
+      transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+    }
+    .idea:hover {
+      transform: translateY(-2px);
+      border-color: #d8e3f8;
+      box-shadow: 0 8px 20px rgba(19, 43, 92, 0.09);
+    }
+
+    .idea-name {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+      word-break: break-word;
+    }
+
+    .idea-votes {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.94rem;
+      font-weight: 600;
+    }
+
+    .vote-btn {
+      justify-self: start;
+      padding: 0.52rem 0.84rem;
+      border-radius: 10px;
+      border: 1px solid #d9e6ff;
+      background: #eef5ff;
+      color: #2b62b8;
+    }
+    .vote-btn:hover:enabled,
+    .vote-btn:focus-visible:enabled {
+      background: #e2edff;
+      transform: translateY(-1px);
+    }
+
+    .empty {
+      margin: 0;
+      color: var(--muted);
+      text-align: center;
+      padding: 1rem 0.5rem;
+      font-weight: 600;
+    }
+
+    footer {
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+      padding: 0.5rem 0 1.7rem;
+    }
+
+    @media (min-width: 640px) {
+      .form-card { padding: 1.1rem; }
+      form { grid-template-columns: 1fr auto; align-items: center; }
+      .idea { grid-template-columns: 1fr auto auto; gap: 1rem; align-items: center; }
+      .vote-btn { justify-self: end; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      * { transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <header class="container">
+    <div class="logo">Pingwi</div>
+    <div class="subtitle">Valkenswaard Community Poll</div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <h1>Welke zaak mist Valkenswaard?</h1>
+      <p class="lead">Deel jouw idee, stem mee en bekijk live resultaten.</p>
+      <div id="counter" class="counter" aria-live="polite">0 inwoners hebben meegedacht</div>
+    </section>
+
+    <section class="card form-card" aria-label="Idee toevoegen">
+      <form id="idea-form" novalidate>
+        <input id="idea-input" type="text" placeholder="Bijv. Aziatische supermarkt" maxlength="80" aria-label="Nieuw idee" />
+        <button id="submit-btn" type="submit" class="btn-primary">Toevoegen</button>
+      </form>
+      <p id="message" class="message" aria-live="polite"></p>
+      <div id="suggestion" class="suggestion" aria-live="polite">
+        <span id="suggestion-text"></span>
+        <button id="suggestion-btn" type="button"></button>
+      </div>
+    </section>
+
+    <section class="card results" aria-label="Resultaten">
+      <ul id="idea-list" class="list"></ul>
+    </section>
+  </main>
+
+  <footer class="container">Een lokaal initiatief van Pingwi.com</footer>
+
+  <script>
+    // ===== API-configuratie =====
+    const API_URL = "PASTE_GOOGLE_APPS_SCRIPT_URL_HERE";
+
+    // ===== Lokale state en hulpsleutels =====
+    const VOTE_COOLDOWN_MS = 12 * 60 * 60 * 1000;
+    const VOTE_HISTORY_KEY = 'pingwi_valkenswaard_vote_history_v1';
+
+    const form = document.getElementById('idea-form');
+    const input = document.getElementById('idea-input');
+    const submitBtn = document.getElementById('submit-btn');
+    const messageEl = document.getElementById('message');
+    const suggestionEl = document.getElementById('suggestion');
+    const suggestionTextEl = document.getElementById('suggestion-text');
+    const suggestionBtn = document.getElementById('suggestion-btn');
+    const listEl = document.getElementById('idea-list');
+    const counterEl = document.getElementById('counter');
+
+    let ideas = [];
+    let loading = false;
+
+    // ===== Initialisatie =====
+    init();
+
+    async function init() {
+      await loadIdeas();
+    }
+
+    // Ideeën ophalen uit Google Apps Script
+    async function loadIdeas() {
+      setLoading(true);
+      try {
+        const response = await fetch(`${API_URL}?action=list`, { method: 'GET' });
+        if (!response.ok) throw new Error('Netwerkfout bij laden.');
+
+        const data = await response.json();
+        if (!Array.isArray(data)) throw new Error('Onjuist dataformaat.');
+
+        ideas = data
+          .filter((item) => item && item.id != null && typeof item.name === 'string')
+          .map((item) => ({
+            id: String(item.id),
+            name: titleCase(item.name.trim()),
+            votes: Number.isFinite(Number(item.votes)) ? Number(item.votes) : 0
+          }))
+          .sort((a, b) => b.votes - a.votes || a.name.localeCompare(b.name, 'nl'));
+
+        renderIdeas(ideas);
+      } catch {
+        showMessage('Er ging iets mis. Probeer opnieuw.');
+        renderIdeas([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    // Resultaten renderen op basis van data
+    function renderIdeas(data) {
+      const sorted = [...data].sort((a, b) => b.votes - a.votes || a.name.localeCompare(b.name, 'nl'));
+      listEl.innerHTML = '';
+
+      if (sorted.length === 0) {
+        listEl.innerHTML = '<li class="empty">Nog geen ideeën toegevoegd. Wees de eerste!</li>';
+        counterEl.textContent = '0 inwoners hebben meegedacht';
+        return;
+      }
+
+      const totalVotes = sorted.reduce((sum, item) => sum + item.votes, 0);
+      const inhabitants = totalVotes + sorted.length;
+      counterEl.textContent = `${inhabitants} inwoners hebben meegedacht`;
+
+      sorted.forEach((idea) => {
+        const item = document.createElement('li');
+        item.className = 'idea';
+
+        const name = document.createElement('p');
+        name.className = 'idea-name';
+        name.textContent = idea.name;
+
+        const votes = document.createElement('p');
+        votes.className = 'idea-votes';
+        votes.textContent = `${idea.votes} ${idea.votes === 1 ? 'stem' : 'stemmen'}`;
+
+        const voteBtn = document.createElement('button');
+        voteBtn.className = 'vote-btn';
+        voteBtn.type = 'button';
+        voteBtn.textContent = 'Stem';
+        voteBtn.disabled = loading || isVoteBlocked(idea.id);
+        voteBtn.addEventListener('click', () => voteIdea(idea.id));
+
+        item.append(name, votes, voteBtn);
+        listEl.appendChild(item);
+      });
+    }
+
+    // Form submit verwerken
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      await submitIdea();
+    });
+
+    // Idee indienen: normaliseren, duplicate/similarity checks en API-call
+    async function submitIdea() {
+      const normalizedDisplay = normalizeText(input.value);
+      hideSuggestion();
+
+      if (normalizedDisplay.length < 2) {
+        showMessage('Er ging iets mis. Probeer opnieuw.');
+        return;
+      }
+
+      // 1) Exacte match: automatisch stemmen op bestaand idee
+      const comparable = comparableText(normalizedDisplay);
+      const exactMatch = ideas.find((idea) => comparableText(idea.name) === comparable);
+      if (exactMatch) {
+        await voteIdea(exactMatch.id);
+        return;
+      }
+
+      // 2) Includes match: suggestie tonen
+      const similar = findSimilar(normalizedDisplay);
+      if (similar) {
+        suggestionTextEl.textContent = `Bedoelde je misschien: ${similar.name}`;
+        suggestionBtn.textContent = `Stem op ${similar.name}`;
+        suggestionBtn.onclick = async () => {
+          await voteIdea(similar.id);
+          hideSuggestion();
+        };
+        suggestionEl.style.display = 'flex';
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch(API_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'submit', name: normalizedDisplay })
+        });
+        if (!response.ok) throw new Error('Submit mislukt.');
+
+        showMessage('Bedankt voor je idee!');
+        input.value = '';
+        await loadIdeas();
+      } catch {
+        showMessage('Er ging iets mis. Probeer opnieuw.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    // Stem uitbrengen op een idee
+    async function voteIdea(id) {
+      if (isVoteBlocked(id)) {
+        showMessage('Je stem is al uitgebracht. Probeer later opnieuw.');
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch(API_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'vote', id: String(id) })
+        });
+        if (!response.ok) throw new Error('Stem mislukt.');
+
+        setVoteBlock(id);
+        showMessage('Je stem is geteld!');
+        await loadIdeas();
+      } catch {
+        showMessage('Er ging iets mis. Probeer opnieuw.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    // Invoer normaliseren conform regels
+    function normalizeText(text) {
+      if (!text) return '';
+      const cleaned = text
+        .toLowerCase('nl-NL')
+        .trim()
+        .replace(/\s+/g, ' ')
+        .replace(/[\p{P}\p{S}]/gu, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      if (cleaned.length < 2) return '';
+      return titleCase(cleaned);
+    }
+
+    // Similariteit zoeken op includes match
+    function findSimilar(text) {
+      const base = comparableText(text);
+      if (!base) return null;
+
+      return ideas.find((idea) => {
+        const current = comparableText(idea.name);
+        return base.includes(current) || current.includes(base);
+      }) || null;
+    }
+
+    // Feedback tonen
+    function showMessage(text) {
+      messageEl.textContent = text;
+    }
+
+    // Helpers
+    function hideSuggestion() {
+      suggestionEl.style.display = 'none';
+      suggestionTextEl.textContent = '';
+      suggestionBtn.textContent = '';
+      suggestionBtn.onclick = null;
+    }
+
+    function comparableText(text) {
+      return String(text || '')
+        .toLowerCase('nl-NL')
+        .trim()
+        .replace(/\s+/g, ' ')
+        .replace(/[\p{P}\p{S}]/gu, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
+    function titleCase(text) {
+      return text
+        .split(' ')
+        .filter(Boolean)
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+    }
+
+    function setLoading(value) {
+      loading = value;
+      submitBtn.disabled = value;
+      input.disabled = value;
+      suggestionBtn.disabled = value;
+      renderIdeas(ideas);
+    }
+
+    function getVoteHistory() {
+      try {
+        const raw = localStorage.getItem(VOTE_HISTORY_KEY);
+        const parsed = raw ? JSON.parse(raw) : {};
+        return parsed && typeof parsed === 'object' ? parsed : {};
+      } catch {
+        return {};
+      }
+    }
+
+    function setVoteBlock(id) {
+      const history = getVoteHistory();
+      history[String(id)] = Date.now();
+      localStorage.setItem(VOTE_HISTORY_KEY, JSON.stringify(history));
+    }
+
+    function isVoteBlocked(id) {
+      const history = getVoteHistory();
+      const ts = Number(history[String(id)] || 0);
+      if (!ts) return false;
+      return Date.now() - ts < VOTE_COOLDOWN_MS;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a localized, self-contained community poll page for Valkenswaard to collect and display ideas and votes. 
- Offer a lightweight front-end that interacts with a Google Apps Script backend via a simple REST-style API. 
- Improve UX with client-side normalization, duplicate/similarity detection and a local vote cooldown to prevent rapid repeat votes.

### Description
- Add `valkenswaard.html`, a full static HTML page with scoped CSS for layout, responsive behavior and accessible UI elements. 
- Implement front-end JavaScript to `fetch` idea lists (`?action=list`), `POST` new ideas (`{ action: 'submit', name }`) and `POST` votes (`{ action: 'vote', id }`) with an `API_URL` placeholder for the Apps Script endpoint. 
- Include input normalization (`normalizeText`), comparable text helpers (`comparableText`), title-casing (`titleCase`), similarity suggestion logic (`findSimilar`) and exact-match auto-vote behavior. 
- Add local vote blocking using `localStorage` with `VOTE_HISTORY_KEY` and a 12-hour cooldown (`VOTE_COOLDOWN_MS`), plus UI state handling via `setLoading` and message/suggestion display functions.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e771a218d4832f89df555183a8448c)